### PR TITLE
Fix trigger when using release drafts before publishing a release.

### DIFF
--- a/.github/workflows/publishRelease.yml
+++ b/.github/workflows/publishRelease.yml
@@ -1,7 +1,7 @@
 name: Publish releases to the Maven Central Repository
 on:
   release:
-    types: [created]
+    types: [published]
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When you do a release but save it as a draft at first and publish it later on, "creation" is not triggered. Therefore, I suggest to use publishing, as described in https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release.